### PR TITLE
Selector

### DIFF
--- a/api.go
+++ b/api.go
@@ -24,6 +24,7 @@ func NewDoc() (*openapi3.Swagger, error) {
       "description": "local development server"
     },
   ],
+  "paths": {}
 }`)
 	return NewDocFromSkeleton(skeleton)
 }

--- a/api_test.go
+++ b/api_test.go
@@ -23,7 +23,7 @@ func TestEmpty(t *testing.T) {
 				}
 				return c.BuildDoc(context.Background(), func(m *reflectopenapi.Manager) {})
 			},
-			Output: "null",
+			Output: "{}",
 		},
 		{
 			Msg: "operation only",

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,0 +1,26 @@
+package reflectopenapi
+
+import (
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/podhmo/reflect-openapi/pkg/shape"
+)
+
+type Extractor interface {
+	Extract(interface{}) shape.Shape
+}
+
+type Selector interface {
+	SelectInput(shape.Function) shape.Shape
+	SelectOutput(shape.Function) shape.Shape
+}
+
+type Resolver interface {
+	ResolveSchema(v *openapi3.Schema, s shape.Shape) *openapi3.SchemaRef
+	ResolveParameter(v *openapi3.Parameter, s shape.Shape) *openapi3.ParameterRef
+	ResolveRequestBody(v *openapi3.RequestBody, s shape.Shape) *openapi3.RequestBodyRef
+	ResolveResponse(v *openapi3.Response, s shape.Shape) *openapi3.ResponseRef
+}
+
+type Binder interface {
+	Bind(doc *openapi3.Swagger)
+}

--- a/resolver.go
+++ b/resolver.go
@@ -62,6 +62,9 @@ func (r *UseRefResolver) ResolveSchema(v *openapi3.Schema, s shape.Shape) *opena
 		if r.AdditionalPropertiesAllowed != nil && v.Type == "object" {
 			v.AdditionalPropertiesAllowed = r.AdditionalPropertiesAllowed
 		}
+		if s.GetName() == "" {
+			return &openapi3.SchemaRef{Value: v}
+		}
 		ref := fmt.Sprintf("#/components/schemas/%s", s.GetName())
 		r.Schemas = append(r.Schemas, &openapi3.SchemaRef{Ref: ref, Value: v})
 		return &openapi3.SchemaRef{Ref: ref, Value: v}

--- a/resolver.go
+++ b/resolver.go
@@ -8,17 +8,6 @@ import (
 	"github.com/podhmo/reflect-openapi/pkg/shape"
 )
 
-type Resolver interface {
-	ResolveSchema(v *openapi3.Schema, s shape.Shape) *openapi3.SchemaRef
-	ResolveParameter(v *openapi3.Parameter, s shape.Shape) *openapi3.ParameterRef
-	ResolveRequestBody(v *openapi3.RequestBody, s shape.Shape) *openapi3.RequestBodyRef
-	ResolveResponse(v *openapi3.Response, s shape.Shape) *openapi3.ResponseRef
-}
-
-type Binder interface {
-	Bind(doc *openapi3.Swagger)
-}
-
 // without ref
 
 type NoRefResolver struct {

--- a/selector.go
+++ b/selector.go
@@ -1,0 +1,32 @@
+package reflectopenapi
+
+import "github.com/podhmo/reflect-openapi/pkg/shape"
+
+type Selector interface {
+	SelectInput(shape.Function) shape.Shape
+	SelectOutput(shape.Function) shape.Shape
+}
+
+type DefaultSelector struct {
+	Extractor *shape.Extractor
+}
+
+func (s *DefaultSelector) SelectInput(fn shape.Function) shape.Shape {
+	if len(fn.Params.Values) == 0 {
+		return nil
+	}
+	for _, inob := range fn.Params.Values {
+		if inob.GetFullName() == "context.Background" {
+			continue
+		}
+		return inob
+	}
+	return nil
+}
+
+func (s *DefaultSelector) SelectOutput(fn shape.Function) shape.Shape {
+	if len(fn.Returns.Values) == 0 {
+		return nil
+	}
+	return fn.Returns.Values[0]
+}

--- a/selector.go
+++ b/selector.go
@@ -2,13 +2,7 @@ package reflectopenapi
 
 import "github.com/podhmo/reflect-openapi/pkg/shape"
 
-type Selector interface {
-	SelectInput(shape.Function) shape.Shape
-	SelectOutput(shape.Function) shape.Shape
-}
-
 type DefaultSelector struct {
-	Extractor *shape.Extractor
 }
 
 func (s *DefaultSelector) SelectInput(fn shape.Function) shape.Shape {

--- a/visitor.go
+++ b/visitor.go
@@ -14,13 +14,8 @@ import (
 	"github.com/podhmo/reflect-openapi/pkg/shape"
 )
 
-// TODO: validation for schema
-// TODO: support function input
 // TODO: extra information
-// TODO: integration with net/http.Handler
-// TODO: integration with fasthttp.Handler
 // TODO: json tag inline,omitempty support
-// TODO: schema required, unrequired support
 // TODO: schema nullable support (?)
 
 // not visitor pattern

--- a/visitor.go
+++ b/visitor.go
@@ -27,22 +27,21 @@ type Visitor struct {
 	Schemas    map[reflect.Type]*openapi3.Schema
 	Operations map[reflect.Type]*openapi3.Operation
 
-	extractor *shape.Extractor
+	extractor Extractor
 }
 
-func NewVisitor(resolver Resolver) *Visitor {
-	e := &shape.Extractor{Seen: map[reflect.Type]shape.Shape{}}
+func NewVisitor(resolver Resolver, selector Selector, extractor Extractor) *Visitor {
 	return &Visitor{
 		Transformer: (&Transformer{
 			cache:            map[reflect.Type]interface{}{},
 			interceptFuncMap: map[reflect.Type]func(shape.Shape) *openapi3.Schema{},
 			Resolver:         resolver,
 			IsRequired:       func(tag reflect.StructTag) bool { return false },
-			Selector:         &DefaultSelector{Extractor: e},
+			Selector:         selector,
 		}).Builtin(),
 		Schemas:    map[reflect.Type]*openapi3.Schema{},
 		Operations: map[reflect.Type]*openapi3.Operation{},
-		extractor:  e,
+		extractor:  extractor,
 	}
 }
 

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -9,7 +9,14 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	reflectopenapi "github.com/podhmo/reflect-openapi"
 	"github.com/podhmo/reflect-openapi/pkg/jsonequal"
+	"github.com/podhmo/reflect-openapi/pkg/shape"
 )
+
+func newVisitor(resolver reflectopenapi.Resolver) *reflectopenapi.Visitor {
+	s := &reflectopenapi.DefaultSelector{}
+	e := &shape.Extractor{Seen: map[reflect.Type]shape.Shape{}}
+	return reflectopenapi.NewVisitor(resolver, s, e)
+}
 
 func TestVisitType(t *testing.T) {
 	cases := []struct {
@@ -80,7 +87,7 @@ func TestVisitType(t *testing.T) {
 		},
 	}
 
-	v := reflectopenapi.NewVisitor(&reflectopenapi.NoRefResolver{})
+	v := newVisitor(&reflectopenapi.NoRefResolver{})
 
 	for _, c := range cases {
 		t.Run(c.Msg, func(t *testing.T) {
@@ -215,7 +222,7 @@ func TestVisitFunc(t *testing.T) {
 		},
 	}
 
-	v := reflectopenapi.NewVisitor(&reflectopenapi.NoRefResolver{})
+	v := newVisitor(&reflectopenapi.NoRefResolver{})
 
 	for _, c := range cases {
 		t.Run(c.Msg, func(t *testing.T) {
@@ -243,7 +250,7 @@ func TestWithRef(t *testing.T) {
 	}
 
 	r := &reflectopenapi.UseRefResolver{}
-	v := reflectopenapi.NewVisitor(r)
+	v := newVisitor(r)
 
 	got := v.VisitType(Group{})
 
@@ -306,7 +313,7 @@ func TestIsRequiredFunction(t *testing.T) {
 	}
 
 	r := &reflectopenapi.NoRefResolver{}
-	v := reflectopenapi.NewVisitor(r)
+	v := newVisitor(r)
 	v.IsRequired = func(tag reflect.StructTag) bool {
 		v, exists := tag.Lookup("required")
 		if !exists {


### PR DESCRIPTION
fix #37 

Define a custom selector , something like this.

```go
type CustomSelector struct {
	reflectopenapi.Selector
	Extractor reflectopenapi.Extractor
}

// wrap with {"items": <>}
func (s *CustomSelector) SelectOutput(fn shape.Function) shape.Shape {
	out := s.Selector.SelectOutput(fn)
	if out, ok := out.(shape.Container); ok && len(out.Args) == 1 {
		rt := reflect.StructOf([]reflect.StructField{
			{
				Name: "Items",
				Type: out.GetReflectType(),
				Tag:  `json:"items"`,
			},
		})
		return s.Extractor.Extract(reflect.New(rt).Interface())
	}
	return out
}
```

and use this.

```go
func main() {
	c := reflectopenapi.Config{
		SkipValidation: true,
	}
	c.Selector = &CustomSelector{
		Selector:  c.DefaultSelector(),
		Extractor: c.DefaultExtractor(),
	}
	c.EmitDoc(func(m *reflectopenapi.Manager) {
		{
			op := m.Visitor.VisitFunc(ListPerson)
			m.Doc.AddOperation("/todo", "GET", op)
		}
		{
			op := m.Visitor.VisitFunc(GetPerson)
			m.Doc.AddOperation("/todo/{id}", "GET", op)
		}
	})
}
```