### PR TITLE
Change Interface, Before() receive shape, After() receive openapi3's object

### DIFF
--- a/_examples/x03null-string/main.go
+++ b/_examples/x03null-string/main.go
@@ -39,7 +39,7 @@ func main() {
 func installNullable(m *reflectopenapi.Manager) {
 	{
 		var v null.Bool
-		m.RegisterType(v).Before(func(schema *openapi3.Schema) {
+		m.RegisterType(v).After(func(schema *openapi3.Schema) {
 			schema.Title = "Null" + schema.Title
 			schema.Nullable = true
 			schema.Properties = nil
@@ -47,7 +47,7 @@ func installNullable(m *reflectopenapi.Manager) {
 	}
 	{
 		var v null.Float
-		m.RegisterType(v).Before(func(schema *openapi3.Schema) {
+		m.RegisterType(v).After(func(schema *openapi3.Schema) {
 			schema.Title = "Null" + schema.Title
 			schema.Nullable = true
 			schema.Properties = nil
@@ -55,7 +55,7 @@ func installNullable(m *reflectopenapi.Manager) {
 	}
 	{
 		var v null.Int
-		m.RegisterType(v).Before(func(schema *openapi3.Schema) {
+		m.RegisterType(v).After(func(schema *openapi3.Schema) {
 			schema.Title = "Null" + schema.Title
 			schema.Type = "integer"
 			schema.Nullable = true
@@ -64,7 +64,7 @@ func installNullable(m *reflectopenapi.Manager) {
 	}
 	{
 		var v null.String
-		m.RegisterType(v).Before(func(schema *openapi3.Schema) {
+		m.RegisterType(v).After(func(schema *openapi3.Schema) {
 			schema.Title = "Null" + schema.Title
 			schema.Type = "string"
 			schema.Nullable = true

--- a/api_test.go
+++ b/api_test.go
@@ -42,8 +42,9 @@ func TestEmpty(t *testing.T) {
 					Extractor:      shapeCfg,
 				}
 				return c.BuildDoc(context.Background(), func(m *reflectopenapi.Manager) {
-					op := m.Visitor.VisitFunc(func() string { return "" })
-					m.Doc.AddOperation("/ping", "GET", op)
+					m.RegisterFunc(func() string { return "" }, func(op *openapi3.Operation) {
+						m.Doc.AddOperation("/ping", "GET", op)
+					})
 				})
 			},
 			Output: `
@@ -84,8 +85,9 @@ func TestEmpty(t *testing.T) {
 					Extractor:      shapeCfg,
 				}
 				return c.BuildDoc(context.Background(), func(m *reflectopenapi.Manager) {
-					op := m.Visitor.VisitFunc(func() string { return "" })
-					m.Doc.AddOperation("/ping", "GET", op)
+					m.RegisterFunc(func() string { return "" }, func(op *openapi3.Operation) {
+						m.Doc.AddOperation("/ping", "GET", op)
+					})
 				})
 			},
 			Output: `
@@ -159,13 +161,13 @@ func TestNameConflict(t *testing.T) {
 			type Sin struct {
 				Value float64
 			}
-			m.Visitor.VisitType(Sin{})
+			m.RegisterType(Sin{})
 
 			type A struct {
 				Sin     *Sin
 				Message string
 			}
-			m.Visitor.VisitType(A{})
+			m.RegisterType(A{})
 		}
 		{
 			type Sin struct {
@@ -174,7 +176,7 @@ func TestNameConflict(t *testing.T) {
 			}
 
 			// name-conflict is occured
-			m.Visitor.VisitType(Sin{})
+			m.RegisterType(Sin{})
 
 			type B struct {
 				Sin     *Sin
@@ -182,7 +184,7 @@ func TestNameConflict(t *testing.T) {
 
 				RelatedList []*Sin
 			}
-			m.Visitor.VisitType(B{})
+			m.RegisterType(B{})
 		}
 		{
 			type Sin struct {
@@ -190,14 +192,14 @@ func TestNameConflict(t *testing.T) {
 			}
 
 			// prevent name-conflict by hand
-			m.Visitor.VisitType(Sin{}, func(s *openapi3.Schema) {
+			m.RegisterType(Sin{}, func(s *openapi3.Schema) {
 				s.Title = "SinForC"
 			})
 
 			type C struct {
 				Sin *Sin
 			}
-			m.Visitor.VisitType(C{})
+			m.RegisterType(C{})
 		}
 	})
 

--- a/dochandler/handler_test.go
+++ b/dochandler/handler_test.go
@@ -24,23 +24,23 @@ func TestEndpoints(t *testing.T) {
 	var handler http.Handler
 	c.BuildDoc(context.Background(), func(m *reflectopenapi.Manager) {
 		{
-			op := m.Visitor.VisitFunc(
-				Hello,
-			)
-			m.Doc.AddOperation("/hello", "POST", op)
+			m.RegisterFunc(Hello).After(func(op *openapi3.Operation) {
+				m.Doc.AddOperation("/hello", "POST", op)
+			})
 		}
 		{
-			op := m.Visitor.VisitFunc(
+			m.RegisterFunc(
 				func(input struct {
 					Name string `json:"name"`
 				}) string {
 					return ""
-				},
+				}).After(
 				func(op *openapi3.Operation) {
 					op.Summary = "Byebye world"
 					op.OperationID = "github.com/podhmo/reflect-openapi/dochandler.Byebye"
+					m.Doc.AddOperation("/byebye", "POST", op)
 				})
-			m.Doc.AddOperation("/byebye", "POST", op)
+
 		}
 		handler = New(m.Doc, "")
 	})

--- a/visitor.go
+++ b/visitor.go
@@ -20,8 +20,6 @@ type Visitor struct {
 	Doc        *openapi3.T
 	Schemas    map[int]*openapi3.Schema
 	Operations map[int]*openapi3.Operation
-
-	extractor Extractor
 }
 
 func isRequiredDefault(tag reflect.StructTag) bool {
@@ -50,12 +48,10 @@ func NewVisitor(tagNameOption TagNameOption, resolver Resolver, selector Selecto
 		Transformer: transformer,
 		Schemas:     map[int]*openapi3.Schema{},
 		Operations:  map[int]*openapi3.Operation{},
-		extractor:   extractor,
 	}
 }
 
-func (v *Visitor) VisitType(ob interface{}, modifiers ...func(*openapi3.Schema)) *openapi3.SchemaRef {
-	in := v.extractor.Extract(ob)
+func (v *Visitor) VisitType(in *shape.Shape, modifiers ...func(*openapi3.Schema)) *openapi3.SchemaRef {
 	out := v.Transform(in).(*openapi3.Schema)
 	out.Title = in.Name
 	for _, m := range modifiers {
@@ -77,8 +73,7 @@ func (v *Visitor) VisitType(ob interface{}, modifiers ...func(*openapi3.Schema))
 	}
 	return v.ResolveSchema(out, in)
 }
-func (v *Visitor) VisitFunc(ob interface{}, modifiers ...func(*openapi3.Operation)) *openapi3.Operation {
-	in := v.extractor.Extract(ob)
+func (v *Visitor) VisitFunc(in *shape.Shape, modifiers ...func(*openapi3.Operation)) *openapi3.Operation {
 	out := v.Transform(in).(*openapi3.Operation)
 
 	if doc := in.Func().Doc(); doc != "" {

--- a/visitor_test.go
+++ b/visitor_test.go
@@ -178,7 +178,7 @@ func TestVisitType(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Msg, func(t *testing.T) {
-			got := v.VisitType(c.Input)
+			got := v.VisitType(v.Transformer.Extractor.Extract(c.Input))
 
 			if err := jsonequal.NoDiff(
 				jsonequal.FromString(c.Output).Named("want"),
@@ -432,7 +432,7 @@ func TestVisitFunc(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.Msg, func(t *testing.T) {
 			v := newVisitor(&reflectopenapi.NoRefResolver{}, c.Selector, c.Extractor)
-			got := v.VisitFunc(c.Input)
+			got := v.VisitFunc(v.Extractor.Extract(c.Input))
 
 			if err := jsonequal.NoDiff(
 				jsonequal.FromString(c.Output).Named("want"),
@@ -488,7 +488,7 @@ func TestWithRef(t *testing.T) {
 	r := &reflectopenapi.UseRefResolver{NameStore: reflectopenapi.NewNameStore()}
 	v := newVisitorDefault(r)
 
-	got := v.VisitType(Group{})
+	got := v.VisitType(v.Extractor.Extract(Group{}))
 
 	t.Run("return value is ref", func(t *testing.T) {
 		want := `{"$ref": "#/components/schemas/Group"}`
@@ -569,7 +569,7 @@ func TestIsRequiredFunction(t *testing.T) {
 	}
 
 	t.Run("plain", func(t *testing.T) {
-		got := v.VisitType(Person{})
+		got := v.VisitType(v.Extractor.Extract(Person{}))
 		want := `
 {
   "properties": {
@@ -603,7 +603,7 @@ func TestIsRequiredFunction(t *testing.T) {
 	})
 
 	t.Run("embedded", func(t *testing.T) {
-		got := v.VisitType(WrapPerson{})
+		got := v.VisitType(v.Extractor.Extract(WrapPerson{}))
 		want := `
 {
   "properties": {


### PR DESCRIPTION
- for #120 

big changes.

- Visitor receives shape.Shape
- RegisterType.Before() receives shape.Shape
- RegisterFunc.Before() receives shape.Func